### PR TITLE
폰트에 맞게 수정

### DIFF
--- a/MoleuGo/src/App.svelte
+++ b/MoleuGo/src/App.svelte
@@ -4,12 +4,14 @@
   import MainPage from './routes/MainPage.svelte';
   import SignupPage from './routes/SignupPage.svelte';
   import FindPassword from './routes/FindPassword.svelte'
+  import BubbleSort from './routes/BubbleSort.svelte';
 
   const routes = {
     '/': Index,
     '/main' : MainPage,
     '/signup': SignupPage,
-    '/findpassword' : FindPassword
+    '/findpassword' : FindPassword,
+    '/visualization/BubbleSort': BubbleSort
   };
 </script>
 

--- a/MoleuGo/src/app.css
+++ b/MoleuGo/src/app.css
@@ -1,5 +1,5 @@
 :root {
-  font: 100% 'Montserrat', sans-serif;
+  font: 100% 'Malgun Gothic', sans-serif;
 }
 
 body {
@@ -30,7 +30,7 @@ main {
 }
 
 .main-list-visible {
-  transform: translateX(210px); 
+  transform: translateX(220px); 
   transition: transform 0.5s ease;
 }
 

--- a/MoleuGo/src/component/AlgorithmList.svelte
+++ b/MoleuGo/src/component/AlgorithmList.svelte
@@ -48,7 +48,7 @@
     }
 
     #algo-list-header-container {
-        padding: 20px 0px 0px 20px;
+        padding: 20px 0px 0px 15px;
         display: flex;
     }
 

--- a/MoleuGo/src/pages/Index.svelte
+++ b/MoleuGo/src/pages/Index.svelte
@@ -19,7 +19,8 @@
     
             <div>
                 <button id="learn-more-btn" on:click={()=> push('/main')}> 더 알아보기</button>
-                <button id="search-start-btn">검색</button>
+                <!-- 임시로 추가. 나중에 삭제 -->
+                <button id="search-start-btn" on:click={()=> push('/visualization/BubbleSort')}>검색</button> 
             </div>
         </div>
      
@@ -43,7 +44,7 @@
     }
 
     #main-left-container {
-        padding: 250px 0px 0px 120px;
+        padding: 280px 0px 0px 120px;
     }
 
     #main-title {

--- a/MoleuGo/src/pages/visualization/BubbleSort.svelte
+++ b/MoleuGo/src/pages/visualization/BubbleSort.svelte
@@ -1,0 +1,13 @@
+<script>
+    import Header from "../../component/Header.svelte";
+</script>
+
+<main>
+    <div class="header-container">
+        <Header/>
+    </div>
+</main>
+
+<style>
+
+</style>

--- a/MoleuGo/src/routes/BubbleSort.svelte
+++ b/MoleuGo/src/routes/BubbleSort.svelte
@@ -1,0 +1,7 @@
+<script>
+    import BubbleSort from "../pages/visualization/BubbleSort.svelte"
+</script>
+  
+<main>
+    <BubbleSort />
+</main>


### PR DESCRIPTION
1. 한/영 둘 다 맑은 고딕 기준으로 개발
2. Index, Header, AlgorithmList 폰트에 맞게 padding 간격 변경
3. app.css의 .main-list-visible의 translateX() 220px로 변경
4. component. pages에 visualization 폴더 생성. 시각화와 관련된  컴포넌트, 페이지는 visualization 하위에 작성 예정
5. Index의 검색 클릭하면 BubbleSort로 넘어가게 함. 알고리즘 리스트 완성되면 수정할 예정