### PR TITLE
2025.05.09 - emailErrorFix

### DIFF
--- a/src/main/java/com/Moleugo/moleugo/repository/animationcount/AnimationCountRepository.java
+++ b/src/main/java/com/Moleugo/moleugo/repository/animationcount/AnimationCountRepository.java
@@ -14,4 +14,11 @@ public interface AnimationCountRepository {
 
     // 회원가입시 DB에 정보주입
     void insert(AnimationCount animationCount);
+
+    //기존 이메일 삭제
+    void deleteByEmail(String email);
+
+    AnimationCount findByEmail(String email);
+
+
 }

--- a/src/main/java/com/Moleugo/moleugo/repository/animationcount/JpaAnimationCountRepository.java
+++ b/src/main/java/com/Moleugo/moleugo/repository/animationcount/JpaAnimationCountRepository.java
@@ -39,4 +39,16 @@ public class JpaAnimationCountRepository implements AnimationCountRepository {
     public void insert(AnimationCount animationCount) {
         em.persist(animationCount);
     }
+
+    @Override
+    public void deleteByEmail(String email) {
+        AnimationCount count = em.find(AnimationCount.class, email);
+        if (count != null) em.remove(count);
+    }
+
+    @Override
+    public AnimationCount findByEmail(String email) {
+        return em.find(AnimationCount.class, email); // ✅ 추가
+    }
+
 }

--- a/src/main/java/com/Moleugo/moleugo/repository/dailygoal/DailyGoalRepository.java
+++ b/src/main/java/com/Moleugo/moleugo/repository/dailygoal/DailyGoalRepository.java
@@ -18,4 +18,6 @@ public interface DailyGoalRepository {
 
     // achieve_count 업데이트
     void updateAchievedCount(DailyGoal dailyGoal);
+
+    void delete(DailyGoal dailyGoal);
 }

--- a/src/main/java/com/Moleugo/moleugo/repository/dailygoal/JpaDailyGoalRepository.java
+++ b/src/main/java/com/Moleugo/moleugo/repository/dailygoal/JpaDailyGoalRepository.java
@@ -42,4 +42,10 @@ public class JpaDailyGoalRepository implements DailyGoalRepository {
     public void updateAchievedCount(DailyGoal dailyGoal) {
         em.merge(dailyGoal);
     }
+
+    @Override
+    public void delete(DailyGoal dailyGoal) {
+        em.remove(em.contains(dailyGoal) ? dailyGoal : em.merge(dailyGoal));
+    }
+
 }

--- a/src/main/java/com/Moleugo/moleugo/repository/member/JpaMemberRepository.java
+++ b/src/main/java/com/Moleugo/moleugo/repository/member/JpaMemberRepository.java
@@ -63,6 +63,12 @@ public class JpaMemberRepository implements MemberRepository {
         em.merge(member);
     }
 
+    // 멤버 삭제
+    @Override
+    public void delete(Member member) {
+        em.remove(em.contains(member) ? member : em.merge(member));
+    }
+
     @Override
     public List<Member> findAll() {
         return em.createQuery("SELECT m FROM Member m", Member.class).getResultList();

--- a/src/main/java/com/Moleugo/moleugo/repository/member/MemberRepository.java
+++ b/src/main/java/com/Moleugo/moleugo/repository/member/MemberRepository.java
@@ -31,6 +31,9 @@ public interface MemberRepository {
     // 멤버 객체 갱신
     void updateMember(Member updatedMember);
 
+    // 삭제
+    void delete(Member member);
+
     // 멤버 객체 모두찾기
     List<Member> findAll();
 }

--- a/src/main/java/com/Moleugo/moleugo/service/member/profile/EmailChangeService.java
+++ b/src/main/java/com/Moleugo/moleugo/service/member/profile/EmailChangeService.java
@@ -1,6 +1,11 @@
 package com.Moleugo.moleugo.service.member.profile;
 
+import com.Moleugo.moleugo.entity.AnimationCount;
+import com.Moleugo.moleugo.entity.DailyGoal;
+import com.Moleugo.moleugo.entity.Id.DailyGoalId;
 import com.Moleugo.moleugo.entity.Member;
+import com.Moleugo.moleugo.repository.animationcount.AnimationCountRepository;
+import com.Moleugo.moleugo.repository.dailygoal.DailyGoalRepository;
 import com.Moleugo.moleugo.repository.member.MemberRepository;
 import com.Moleugo.moleugo.service.member.auth.AuthService;
 import com.Moleugo.moleugo.service.member.mail.MailService;
@@ -11,6 +16,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import java.util.Enumeration;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -19,12 +25,11 @@ public class EmailChangeService {
 
     private final HttpSession session;
     private final MemberRepository memberRepository;
+    private final AnimationCountRepository animationCountRepository;
+    private final DailyGoalRepository dailyGoalRepository;
     private final MailService mailService;
     private final AuthService authService;
 
-    /**
-     * 현재 로그인한 사용자로부터 이메일 변경 요청을 받아 새 이메일로 인증 메일 전송
-     */
     public HttpStatus requestEmailChange(String sessionId, String newEmail) {
         Member currentMember = (Member) session.getAttribute(sessionId);
         if (currentMember == null) return HttpStatus.UNAUTHORIZED;
@@ -33,10 +38,9 @@ public class EmailChangeService {
             return HttpStatus.CONFLICT;
         }
 
-        // 새 Member 정보와 함께 기존 이메일도 따로 저장
         Member newMember = new Member(newEmail, currentMember.getPassword(), currentMember.getAccount_type());
         String uuid = authService.createSession(newMember, 1800);
-        session.setAttribute("old_email_" + uuid, currentMember.getEmail()); // 기존 이메일 저장
+        session.setAttribute("old_email_" + uuid, currentMember.getEmail());
 
         String verificationLink = "http://localhost:8080/user/change-email/" + uuid;
         String content = """
@@ -53,9 +57,6 @@ public class EmailChangeService {
         return HttpStatus.OK;
     }
 
-    /**
-     * 인증 메일 링크 클릭 시 이메일을 실제로 변경
-     */
     public HttpStatus confirmEmailChange(String uuid) {
         Member sessionMember = (Member) session.getAttribute(uuid);
         String oldEmail = (String) session.getAttribute("old_email_" + uuid);
@@ -67,7 +68,6 @@ public class EmailChangeService {
         session.removeAttribute(uuid);
         session.removeAttribute("old_email_" + uuid);
 
-        //새 Member 구성 (모든 필드 복사)
         Member oldMember = memberRepository.findByEmail(oldEmail);
         Member newMember = new Member(
                 sessionMember.getEmail(),
@@ -76,11 +76,48 @@ public class EmailChangeService {
                 null,
                 oldMember.getNickname()
         );
+        memberRepository.registerMember(newMember);
 
-        // Repository에 "저장/삭제" 요청
-        memberRepository.updateEmail(newMember, oldEmail);
+        // AnimationCount 마이그레이션
+        AnimationCount oldCount = animationCountRepository.findByEmail(oldEmail);
+        if (oldCount != null) {
+            AnimationCount newCount = new AnimationCount();
+            newCount.setEmail(newMember.getEmail());
+            newCount.setLinkedList(oldCount.getLinkedList());
+            newCount.setStack(oldCount.getStack());
+            newCount.setQueue(oldCount.getQueue());
+            newCount.setDeque(oldCount.getDeque());
+            newCount.setHeap(oldCount.getHeap());
+            newCount.setBinarySearch(oldCount.getBinarySearch());
+            newCount.setBubbleSort(oldCount.getBubbleSort());
+            newCount.setSelectionSort(oldCount.getSelectionSort());
+            newCount.setInsertionSort(oldCount.getInsertionSort());
+            newCount.setDfs(oldCount.getDfs());
+            newCount.setBfs(oldCount.getBfs());
+            newCount.setDijkstra(oldCount.getDijkstra());
+            newCount.setBellmanFord(oldCount.getBellmanFord());
+            newCount.setFloydWarshall(oldCount.getFloydWarshall());
+            newCount.setConvexHull(oldCount.getConvexHull());
+            animationCountRepository.insert(newCount);
+            animationCountRepository.deleteByEmail(oldEmail);
+        }
 
-        // 세션 갱신
+        // DailyGoal 마이그레이션
+        List<DailyGoal> oldGoals = dailyGoalRepository.findAllByEmail(oldEmail);
+        for (DailyGoal oldGoal : oldGoals) {
+            DailyGoalId oldId = oldGoal.getId();
+            DailyGoalId newId = new DailyGoalId(newMember.getEmail(), oldId.getGoalDate());
+            DailyGoal newGoal = new DailyGoal();
+            newGoal.setId(newId);
+            newGoal.setAchievedCount(oldGoal.getAchievedCount());
+            newGoal.setAchievedListJson(oldGoal.getAchievedListJson());
+            newGoal.setGoalListJson(oldGoal.getGoalListJson());
+            dailyGoalRepository.save(newGoal);
+            dailyGoalRepository.delete(oldGoal);
+        }
+
+        memberRepository.delete(oldMember);
+
         Enumeration<String> attributeNames = session.getAttributeNames();
         while (attributeNames.hasMoreElements()) {
             String attr = attributeNames.nextElement();
@@ -95,5 +132,4 @@ public class EmailChangeService {
 
         return HttpStatus.OK;
     }
-
 }


### PR DESCRIPTION
1. 이메일 변경 시 참조테이블 데이터 삭제 오류 고침
2. 로직은 기존 이메일 삭제 -> 새 이메일 삽입 그대로긴 하지만 관련된 데이터 모두 복사 되게 만들었으니 기능 상 문제는 없음, 버그 발견시 카톡 부탁